### PR TITLE
Allow for hyphens in factory names

### DIFF
--- a/public/javascripts/backbone-factory.js
+++ b/public/javascripts/backbone-factory.js
@@ -10,7 +10,7 @@
     define: function(factory_name, klass, defaults){
 
       // Check for arguments' sanity
-      if(factory_name.match(/[^\w_]+/)){
+      if(factory_name.match(/[^\w-_]+/)){
         throw "Factory name should not contain spaces or other funky characters";
       }
 

--- a/spec/javascripts/BackboneFactorySpec.js
+++ b/spec/javascripts/BackboneFactorySpec.js
@@ -90,6 +90,10 @@ describe("Backbone Factory", function() {
       it("should throw an error if factory_name is not proper", function() {
         expect(function(){BackboneFactory.define('wrong name', Post)}).toThrow("Factory name should not contain spaces or other funky characters");
       });
+      
+      it("should not throw an error if factory_name has a hyphen", function() {
+        expect(function(){BackboneFactory.define('okay-name', Post)}).not.toThrow();
+      });
 
       it("should throw an error if you try to use an undefined factory", function() {
         expect(function(){BackboneFactory.create('undefined_factory')}).toThrow("Factory with name undefined_factory does not exist");


### PR DESCRIPTION
I'd like to be able to use a hyphen in factory names. If there's no reason to disallow them, here's a pull request that does just that.

Thanks!
